### PR TITLE
fix check in retrieve_links

### DIFF
--- a/R/retrieve_links.R
+++ b/R/retrieve_links.R
@@ -55,7 +55,7 @@ retrieve_links <- function(ArchiveUrls,
 
 
   # Check Archive Url input
-  if (!nonArchive & !stringr::str_detect(ArchiveUrls, "web\\.archive\\.org"))
+  if (!nonArchive & !all(stringr::str_detect(ArchiveUrls, "web\\.archive\\.org")))
     stop("Urls need to be Internet Archive Urls. Please use the retrieve_urls function to obtain mementos from the Internet Archive.")
 
   # Encoding must be character

--- a/tests/testthat/test_retrieve_links.R
+++ b/tests/testthat/test_retrieve_links.R
@@ -23,6 +23,19 @@ test_that("retrieve_links() requires encoding to be character", {
   )
 })
 
+test_that("retrieve_links() requires webarchive urls", {
+  expect_error(
+    retrieve_links(
+      c(
+        "https://web.archive.org/web/20210101/example.com",
+        "https://web.org/web/20210202/test.com"
+      ),
+      nonArchive = F
+    ),
+    "Urls need to be Internet Archive Urls"
+  )
+})
+
 #Check that encoding is character with length 1
 test_that("retrieve_links() requires encoding to be character with length 1",
           {


### PR DESCRIPTION
Bug: Missing `all()` in Archive URL validation causes error

Hi! Thanks for creating archiveRetriever - really useful package! 🎉

The current URL validation check in `retrieve_links` throws an error when checking multiple URLs:
```r
if (!nonArchive & !stringr::str_detect(ArchiveUrls, "web\\.archive\\.org"))
  stop("Urls need to be Internet Archive Urls...")
```

This is because`str_detect()` returns a vector (one TRUE/FALSE per URL), but `if()` expects a single value.

**Error:**
```
Error in `if (!nonArchive & !stringr::str_detect(ArchiveUrls, "web\\.archive\\.org"))`:
! the condition has length > 1
```

The solution is to wrap it in all() 
```r
if (!nonArchive & !all(stringr::str_detect(ArchiveUrls, "web\\.archive\\.org")))
  stop("Urls need to be Internet Archive Urls...")
```

This properly checks that **all** URLs are archive URLs.

I'm submitting a PR with this fix. Thanks! 🙏